### PR TITLE
Remove the trailing dot in the password field in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var client = new SSHClient(
   host: "my.sshtest",
   port: 22,
   username: "sha",
-  passwordOrKey: "Password01.",
+  passwordOrKey: "Password01",
 );
 ```
 


### PR DESCRIPTION
Hello!

This is the smallest PR ever seen. This PR just removes the trailing dot of the password field. Why? Too simple... when the user copypastes the example in their code and replaces the example password with the actual one, when selecting the example password doing a double click, the dot is not selected. So, when pasting the actual password, it will have a dot in the end. The user won't see it and will be blaming the library for no reason.

Thanks for your work! 👍 